### PR TITLE
Fix: Verify generated file imports and theme types for Flutter 3.3.x

### DIFF
--- a/paw_sync/lib/core/theme/theme.dart
+++ b/paw_sync/lib/core/theme/theme.dart
@@ -293,6 +293,10 @@ ThemeData getAppThemeData(BuildContext context) {
     ),
 
     // Card theme
+    // Note: User reported a type error on Flutter 3.3.x (CardTheme vs CardThemeData?).
+    // The current implementation uses `CardTheme`, which is the standard Flutter API class name
+    // for the `ThemeData.cardTheme` property. If issues persist after resolving import errors
+    // and cleaning the build, this might indicate a specific nuance of the 3.3.25 environment.
     cardTheme: CardTheme(
       elevation: 2.0,
       shape: RoundedRectangleBorder(
@@ -332,6 +336,9 @@ ThemeData getAppThemeData(BuildContext context) {
 
     // Define other component themes as needed (e.g., dialogTheme, chipTheme, etc.)
     // Example: Dialog Theme
+    // Note: User reported a type error on Flutter 3.3.x (DialogTheme vs DialogThemeData?).
+    // The current implementation uses `DialogTheme`, which is the standard Flutter API class name
+    // for the `ThemeData.dialogTheme` property.
     dialogTheme: DialogTheme(
       backgroundColor: AppColors.surface,
       titleTextStyle: AppTextStyles.titleLarge.copyWith(color: AppColors.textPrimary),


### PR DESCRIPTION
- Verified that import paths for `firebase_options.dart` and `app_localizations.dart` in `main.dart` are standard.
- Verified that `l10n.yaml` configuration is standard for the `app_localizations.dart` import path.
- Confirmed that `CardTheme` and `DialogTheme` instantiations in `theme.dart` use the correct standard Flutter API class names.
- Added comments in `theme.dart` regarding user-reported type issues on Flutter 3.3.x, suggesting potential environment or analyzer causes if underlying import/generation issues persist locally for the user.

No significant code logic changes were made, as the primary issues reported by the user are likely related to their local build environment and generation of files.