### PR TITLE
Fix: Remove fireImmediately from router and set initial state manually

### DIFF
--- a/paw_sync/lib/core/routing/app_router.dart
+++ b/paw_sync/lib/core/routing/app_router.dart
@@ -60,9 +60,10 @@ class AppRouter {
       (previous, next) {
         authStateNotifier.value = next;
       },
-      // Fire immediately to get the initial state
-      fireImmediately: true,
     );
+    // Manually set the initial value for authStateNotifier
+    // This replaces the need for `fireImmediately: true` which might not be available in older Riverpod.
+    authStateNotifier.value = ref.read(authNotifierProvider);
 
     // Ensure the subscription is cancelled when the notifier is disposed.
     // This is tricky with a static getRouter. In a real app, the GoRouter


### PR DESCRIPTION
- In app_router.dart, removed `fireImmediately: true` from the ref.listen call for authNotifierProvider.
- Added `authStateNotifier.value = ref.read(authNotifierProvider)` immediately after setting up the listener to ensure the ValueNotifier for refreshListenable has the correct initial auth state.

This addresses a compilation error related to `fireImmediately` in older Riverpod versions or specific Flutter environments like 3.3.x.