### PR TITLE
Fix: Correct ref.listen usage in app_router.dart

### DIFF
--- a/paw_sync/lib/core/routing/app_router.dart
+++ b/paw_sync/lib/core/routing/app_router.dart
@@ -55,7 +55,8 @@ class AppRouter {
     // or accept that this subscription lives for the app's lifetime if not managed.
     // For simplicity here, we'll assume it's managed or short-lived for setup.
     // A more robust solution might involve a dedicated Riverpod provider for the router itself.
-    final StreamSubscription<AsyncValue<dynamic>>? subscription = ref.listen<AsyncValue<dynamic>>(
+    // The StreamSubscription is not stored as its lifecycle isn't easily managed in this static context.
+    ref.listen<AsyncValue<dynamic>>(
       authNotifierProvider,
       (previous, next) {
         authStateNotifier.value = next;


### PR DESCRIPTION
- Modified app_router.dart to not assign the result of ref.listen to a StreamSubscription variable when setting up the listener for authNotifierProvider.
- This resolves the error "This expression has type 'void' and can't be used."
- The listener continues to update the ValueNotifier for GoRouter's refreshListenable, and the initial value is still set via ref.read.