### PR TITLE
feat: Implement logout and display real pets on PetProfileScreen

### DIFF
--- a/paw_sync/lib/core/auth/providers/auth_providers.dart
+++ b/paw_sync/lib/core/auth/providers/auth_providers.dart
@@ -62,10 +62,10 @@ final currentUserModelProvider = Provider<UserModel?>((ref) {
 });
 
 
-// TODO: Implement an AsyncNotifier or StateNotifier for authentication actions
-// for more robust state management (loading, error handling).
-// The providers below are simplified for API definition.
-// This notifier will handle methods like:
+// The AuthNotifier (see auth_notifier.dart and authNotifierProvider below)
+// now serves the purpose of robust state management for authentication actions.
+// The providers below this comment are simplified for direct API definition or specific use cases
+// but primary UI interaction for auth operations should go through authNotifierProvider.
 // --- Mutation Providers (simplified for API definition) ---
 
 // Provider for signing in with email and password.


### PR DESCRIPTION
- Implemented logout functionality on PetProfileScreen using AuthNotifier.
- Modified PetProfileScreen to use currentUserPetsStreamProvider to fetch and display a live list of the user's pets from Firestore.
- Handles loading, error, and empty states for the pet list.
- Pet cards now display name, species, breed, and attempt to load photoUrl.
- Removed placeholder pet data from PetProfileScreen.
- Cleaned up an outdated TODO comment in auth_providers.dart.

Further work on adding/viewing pet details will be in subsequent rounds.