### PR TITLE
feat: Implement 'Add Pet' functionality

### DIFF
--- a/paw_sync/lib/core/routing/app_router.dart
+++ b/paw_sync/lib/core/routing/app_router.dart
@@ -11,6 +11,7 @@ import 'package:paw_sync/core/auth/providers/auth_providers.dart'; // Import aut
 import 'package:paw_sync/core/auth/screens/login_screen.dart';
 import 'package:paw_sync/core/auth/screens/sign_up_screen.dart'; // Import SignUpScreen
 import 'package:paw_sync/core/auth/screens/splash_screen.dart';
+import 'package:paw_sync/features/pet_profile/screens/add_pet_screen.dart'; // Import AddPetScreen
 import 'package:paw_sync/features/pet_profile/screens/pet_profile_screen.dart';
 // TODO: Import other screens as they are created.
 
@@ -21,6 +22,7 @@ class AppRoutes {
   static const String login = '/login';
   static const String home = '/home'; // Represents the main screen after login, e.g., pet profiles
   static const String signUp = '/signUp'; // Route for the sign-up screen
+  static const String addPet = '/add-pet'; // Route for adding a new pet
   // Add other route names here e.g.
   // static const String petDetails = '/pet/:id'; // Example with path parameter
 }
@@ -153,6 +155,19 @@ class AppRouter {
           builder: (BuildContext context, GoRouterState state) {
             return const SignUpScreen(); // Use the new SignUpScreen
           },
+        ),
+
+        // Add Pet Screen Route
+        GoRoute(
+          path: AppRoutes.addPet,
+          name: AppRoutes.addPet,
+          builder: (BuildContext context, GoRouterState state) {
+            return const AddPetScreen();
+          },
+          // This route should only be accessible if logged in.
+          // The main redirect logic already handles redirecting to login if not authenticated.
+          // If specific parent-child navigation is needed (e.g. /home/add-pet),
+          // this could be a sub-route of AppRoutes.home. For now, a top-level route is fine.
         ),
       ],
 

--- a/paw_sync/lib/features/pet_profile/screens/add_pet_screen.dart
+++ b/paw_sync/lib/features/pet_profile/screens/add_pet_screen.dart
@@ -1,0 +1,207 @@
+// lib/features/pet_profile/screens/add_pet_screen.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart'; // For date formatting
+import 'package:paw_sync/core/auth/providers/auth_providers.dart'; // For currentUserIdProvider indirectly via pet_providers
+import 'package:paw_sync/features/pet_profile/models/pet_model.dart';
+import 'package:paw_sync/features/pet_profile/providers/pet_providers.dart';
+import 'package:paw_sync/core/widgets/themed_buttons.dart'; // Assuming this exists and is suitable
+
+class AddPetScreen extends ConsumerStatefulWidget {
+  const AddPetScreen({super.key});
+
+  @override
+  ConsumerState<AddPetScreen> createState() => _AddPetScreenState();
+}
+
+class _AddPetScreenState extends ConsumerState<AddPetScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _nameController;
+  late TextEditingController _speciesController;
+  late TextEditingController _breedController;
+  late TextEditingController _photoUrlController;
+  DateTime? _selectedBirthDate;
+
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController();
+    _speciesController = TextEditingController();
+    _breedController = TextEditingController();
+    _photoUrlController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _speciesController.dispose();
+    _breedController.dispose();
+    _photoUrlController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selectBirthDate(BuildContext context) async {
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedBirthDate ?? DateTime.now(),
+      firstDate: DateTime(1980), // Arbitrary past date
+      lastDate: DateTime.now(),   // Pet cannot be born in the future
+    );
+    if (picked != null && picked != _selectedBirthDate) {
+      setState(() {
+        _selectedBirthDate = picked;
+      });
+    }
+  }
+
+  Future<void> _submitForm() async {
+    if (_formKey.currentState?.validate() ?? false) {
+      setState(() {
+        _isLoading = true;
+      });
+
+      final currentUserId = ref.read(currentUserIdProvider);
+      if (currentUserId == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Error: User not logged in. Cannot add pet.')),
+        );
+        setState(() { _isLoading = false; });
+        return;
+      }
+
+      // Let Firestore generate the ID by passing an empty string or ensuring Pet model handles it.
+      // The existing FirebasePetRepository handles empty ID by letting Firestore generate it.
+      final newPet = Pet(
+        id: '', // Firestore will generate this
+        ownerId: currentUserId,
+        name: _nameController.text.trim(),
+        species: _speciesController.text.trim(),
+        breed: _breedController.text.trim().isNotEmpty ? _breedController.text.trim() : null,
+        birthDate: _selectedBirthDate,
+        photoUrl: _photoUrlController.text.trim().isNotEmpty ? _photoUrlController.text.trim() : null,
+        // Initialize other fields as needed, e.g., empty lists or null
+        vaccinationRecords: [],
+        medicalHistory: [],
+      );
+
+      try {
+        // Use the addPetProvider from pet_providers.dart
+        // addPetProvider is a simple Provider that returns a function.
+        // This function, when called, executes the repository's addPet method
+        // and handles provider invalidation.
+        final addPetAction = ref.read(addPetProvider);
+        await addPetAction(newPet);
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${newPet.name} added successfully!')),
+        );
+        if (mounted) {
+          Navigator.of(context).pop(); // Go back to pet profile screen
+        }
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error adding pet: ${e.toString()}')),
+        );
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isLoading = false;
+          });
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Add New Pet'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Text('Pet Details', style: textTheme.titleLarge?.copyWith(color: colorScheme.primary)),
+              const SizedBox(height: 24),
+
+              // Name Field
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter the pet\'s name.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Species Field
+              TextFormField(
+                controller: _speciesController,
+                decoration: const InputDecoration(labelText: 'Species (e.g., Dog, Cat)'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter the pet\'s species.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Breed Field
+              TextFormField(
+                controller: _breedController,
+                decoration: const InputDecoration(labelText: 'Breed (Optional)'),
+                // No validator, as it's optional
+              ),
+              const SizedBox(height: 16),
+
+              // Birth Date Field
+              TextFormField(
+                decoration: InputDecoration(
+                  labelText: 'Birth Date (Optional)',
+                  hintText: 'Select Date',
+                  suffixIcon: Icon(Icons.calendar_today, color: colorScheme.primary),
+                ),
+                readOnly: true,
+                controller: TextEditingController(
+                  text: _selectedBirthDate == null
+                      ? ''
+                      : DateFormat.yMMMd().format(_selectedBirthDate!), // e.g., Jan 23, 2023
+                ),
+                onTap: () => _selectBirthDate(context),
+              ),
+              const SizedBox(height: 16),
+
+              // Photo URL Field
+              TextFormField(
+                controller: _photoUrlController,
+                decoration: const InputDecoration(labelText: 'Photo URL (Optional)'),
+                keyboardType: TextInputType.url,
+                // No validator, as it's optional. Basic URL validation could be added later.
+              ),
+              const SizedBox(height: 32),
+
+              PrimaryActionButton(
+                text: 'Save Pet',
+                isLoading: _isLoading,
+                onPressed: _isLoading ? null : _submitForm,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/paw_sync/lib/features/pet_profile/screens/pet_profile_screen.dart
+++ b/paw_sync/lib/features/pet_profile/screens/pet_profile_screen.dart
@@ -66,8 +66,9 @@ class PetProfileScreen extends ConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
-          // TODO: Navigate to add pet screen
-          print('Add new pet FAB pressed');
+          // Navigate to add pet screen
+          GoRouter.of(context).push(AppRoutes.addPet);
+          print('Add new pet FAB pressed, navigating to ${AppRoutes.addPet}');
         },
         label: const Text('Add Pet'),
         icon: const Icon(Icons.add),


### PR DESCRIPTION
- Created AddPetScreen with a form for pet details (name, species, breed, birth date, photo URL).
- Implemented form validation and submission logic, including date picker for birth date.
- Integrated with addPetProvider to save new pets to Firestore, relying on Firestore for auto-ID generation.
- Added user feedback (loading indicators, success/error SnackBars) and navigation back to PetProfileScreen on success.
- Updated AppRouter with a route for AddPetScreen.
- Connected the FAB on PetProfileScreen to navigate to AddPetScreen.

Users can now add pets to their profile. Viewing full pet details and editing/deleting pets are planned for future rounds.