### PR TITLE
feat: Implement CRUD for Pet Grooming Preferences

### DIFF
--- a/lib/features/pet_profile/widgets/save_grooming_preferences_form.dart
+++ b/lib/features/pet_profile/widgets/save_grooming_preferences_form.dart
@@ -1,0 +1,156 @@
+// lib/features/pet_profile/widgets/save_grooming_preferences_form.dart
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'; // For TextInputFormatter
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:paw_sync/features/pet_profile/models/pet_model.dart';
+import 'package:paw_sync/core/widgets/themed_buttons.dart';
+
+class SaveGroomingPreferencesForm extends ConsumerStatefulWidget {
+  final GroomingPreferences? existingPreferences;
+  final Function(GroomingPreferences) onSave;
+
+  const SaveGroomingPreferencesForm({
+    super.key,
+    this.existingPreferences,
+    required this.onSave,
+  });
+
+  @override
+  ConsumerState<SaveGroomingPreferencesForm> createState() => _SaveGroomingPreferencesFormState();
+}
+
+class _SaveGroomingPreferencesFormState extends ConsumerState<SaveGroomingPreferencesForm> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _preferredGroomerController;
+  late TextEditingController _cutStyleController;
+  late TextEditingController _frequencyController;
+  late TextEditingController _notesController;
+
+  bool get _isEditMode => widget.existingPreferences != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final prefs = widget.existingPreferences;
+    _preferredGroomerController = TextEditingController(text: prefs?.preferredGroomer);
+    _cutStyleController = TextEditingController(text: prefs?.cutStyle);
+    _frequencyController = TextEditingController(text: prefs?.frequencyInWeeks?.toString());
+    // Join list of notes into a single string for multiline TextField, separated by newlines.
+    // If notes list is null or empty, initialize with an empty string.
+    _notesController = TextEditingController(text: prefs?.notes?.join('\n') ?? '');
+  }
+
+  @override
+  void dispose() {
+    _preferredGroomerController.dispose();
+    _cutStyleController.dispose();
+    _frequencyController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  void _submitForm() {
+    if (_formKey.currentState?.validate() ?? false) {
+      final frequencyText = _frequencyController.text.trim();
+      final notesText = _notesController.text.trim();
+
+      final newPreferences = GroomingPreferences(
+        preferredGroomer: _preferredGroomerController.text.trim().isNotEmpty
+            ? _preferredGroomerController.text.trim()
+            : null,
+        cutStyle: _cutStyleController.text.trim().isNotEmpty
+            ? _cutStyleController.text.trim()
+            : null,
+        frequencyInWeeks: frequencyText.isNotEmpty
+            ? int.tryParse(frequencyText)
+            : null,
+        // Split notes back into a list if not empty, otherwise null.
+        notes: notesText.isNotEmpty ? notesText.split('\n').map((e) => e.trim()).where((e) => e.isNotEmpty).toList() : null,
+      );
+
+      // Check if all fields are effectively null/empty. If so, treat as clearing preferences.
+      // (This logic might need refinement based on desired "clear" behavior)
+      bool allFieldsEmpty = (newPreferences.preferredGroomer == null || newPreferences.preferredGroomer!.isEmpty) &&
+                            (newPreferences.cutStyle == null || newPreferences.cutStyle!.isEmpty) &&
+                            newPreferences.frequencyInWeeks == null &&
+                            (newPreferences.notes == null || newPreferences.notes!.isEmpty);
+
+      // For V1, we always save the object. If all fields are empty, it's an object with nulls.
+      // True deletion (setting pet.groomingPreferences to null) can be handled by a separate "Remove" button if needed.
+      widget.onSave(newPreferences);
+      Navigator.of(context).pop(); // Close the modal bottom sheet
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+        left: 16,
+        right: 16,
+        top: 20,
+      ),
+      child: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Text(
+                _isEditMode ? 'Edit Grooming Preferences' : 'Add Grooming Preferences',
+                style: Theme.of(context).textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              TextFormField(
+                controller: _preferredGroomerController,
+                decoration: const InputDecoration(labelText: 'Preferred Groomer (Optional)'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _cutStyleController,
+                decoration: const InputDecoration(labelText: 'Cut Style (Optional)'),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _frequencyController,
+                decoration: const InputDecoration(labelText: 'Frequency in Weeks (Optional)'),
+                keyboardType: TextInputType.number,
+                inputFormatters: <TextInputFormatter>[
+                  FilteringTextInputFormatter.digitsOnly
+                ],
+                validator: (value) {
+                  if (value != null && value.trim().isNotEmpty) {
+                    if (int.tryParse(value.trim()) == null) {
+                      return 'Please enter a valid number.';
+                    }
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _notesController,
+                decoration: const InputDecoration(
+                  labelText: 'Notes (Optional)',
+                  hintText: 'Enter any grooming notes, one per line if desired.',
+                  alignLabelWithHint: true,
+                ),
+                maxLines: 3,
+                textInputAction: TextInputAction.newline, // Allows newlines
+              ),
+              const SizedBox(height: 24),
+              PrimaryActionButton(
+                text: _isEditMode ? 'Update Preferences' : 'Save Preferences',
+                onPressed: _submitForm,
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/paw_sync/lib/features/pet_profile/screens/pet_detail_screen.dart
+++ b/paw_sync/lib/features/pet_profile/screens/pet_detail_screen.dart
@@ -5,7 +5,8 @@ import 'package:intl/intl.dart'; // For date formatting
 import 'package:paw_sync/features/pet_profile/models/pet_model.dart';
 import 'package:paw_sync/features/pet_profile/providers/pet_providers.dart';
 import 'package:paw_sync/features/pet_profile/widgets/save_vaccination_record_form.dart';
-import 'package:paw_sync/features/pet_profile/widgets/save_medical_event_form.dart'; // Import the medical event form
+import 'package:paw_sync/features/pet_profile/widgets/save_medical_event_form.dart';
+import 'package:paw_sync/features/pet_profile/widgets/save_grooming_preferences_form.dart'; // Import the grooming form
 
 class PetDetailScreen extends ConsumerWidget {
   final String petId;
@@ -206,17 +207,36 @@ class PetDetailScreen extends ConsumerWidget {
                 const SizedBox(height: 16),
                 Divider(),
 
-                // Grooming Preferences Section (if available)
-                if (pet.groomingPreferences != null) ...[
-                  _buildSectionTitle(context, 'Grooming Preferences'),
+                // Grooming Preferences Section
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    _buildSectionTitle(context, 'Grooming Preferences'),
+                    IconButton(
+                      icon: Icon(pet.groomingPreferences != null ? Icons.edit_outlined : Icons.add_circle_outline, color: colorScheme.primary),
+                      tooltip: pet.groomingPreferences != null ? 'Edit Grooming Preferences' : 'Add Grooming Preferences',
+                      onPressed: () {
+                        _showSaveGroomingPreferencesSheet(context, ref, pet);
+                      },
+                    ),
+                  ],
+                ),
+                if (pet.groomingPreferences == null)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: const Text('No grooming preferences set.'),
+                  )
+                else ...[
                   _buildDetailRow(context, 'Preferred Groomer:', pet.groomingPreferences!.preferredGroomer ?? 'N/A'),
                   _buildDetailRow(context, 'Cut Style:', pet.groomingPreferences!.cutStyle ?? 'N/A'),
                   _buildDetailRow(context, 'Frequency:', pet.groomingPreferences!.frequencyInWeeks != null ? '${pet.groomingPreferences!.frequencyInWeeks} weeks' : 'N/A'),
                   if (pet.groomingPreferences!.notes != null && pet.groomingPreferences!.notes!.isNotEmpty)
-                    _buildNotesList(context, 'Notes:', pet.groomingPreferences!.notes!),
+                    _buildNotesList(context, 'Notes:', pet.groomingPreferences!.notes!)
+                  else
+                     _buildDetailRow(context, 'Notes:', 'N/A'),
                   const SizedBox(height: 16),
-                  Divider(),
                 ],
+                Divider(),
 
                 // Behavior Profile Section (if available)
                 if (pet.behaviorProfile != null) ...[
@@ -605,5 +625,44 @@ class PetDetailScreen extends ConsumerWidget {
       }
       // PetDetailScreen will rebuild due to petByIdProvider update.
     }
+  }
+
+  void _showSaveGroomingPreferencesSheet(
+    BuildContext context,
+    WidgetRef ref,
+    Pet pet,
+  ) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext bottomSheetContext) {
+        return SaveGroomingPreferencesForm(
+          existingPreferences: pet.groomingPreferences, // Pass existing or null
+          onSave: (GroomingPreferences savedPreferences) async {
+            // Determine if all fields in savedPreferences are null or empty
+            // This helps decide if we should set groomingPreferences to null on the Pet object
+            // or save the new (potentially all-empty) GroomingPreferences object.
+            // For V1, we save the object even if all its fields are null/empty,
+            // rather than setting pet.groomingPreferences itself to null.
+            // A "Remove Preferences" button could explicitly set it to null.
+
+            final updatedPet = pet.copyWith(groomingPreferences: savedPreferences);
+
+            try {
+              final updatePetAction = ref.read(updatePetProvider);
+              await updatePetAction(updatedPet);
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Grooming preferences updated successfully!')),
+              );
+            } catch (e) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Error updating grooming preferences: ${e.toString()}')),
+              );
+            }
+            // PetDetailScreen will rebuild automatically.
+          },
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
- Enhanced PetDetailScreen to display grooming preferences with a dynamic add/edit button.
- Null/empty fields within grooming preferences are gracefully handled with 'N/A' display.
- Created SaveGroomingPreferencesForm (modal bottom sheet) for adding/editing details (preferred groomer, cut style, frequency, notes) with validation for frequency.
- Implemented logic in PetDetailScreen to handle saving grooming preferences by updating the Pet model's `groomingPreferences` object and calling `updatePetProvider`.
- Clearing all fields in the form effectively clears the displayed preferences.
- User feedback (SnackBars) provided for save operations.