### PR TITLE
fix: Address various compilation errors

### DIFF
--- a/paw_sync/lib/core/routing/app_router.dart
+++ b/paw_sync/lib/core/routing/app_router.dart
@@ -5,6 +5,7 @@
 import 'dart:async'; // For StreamSubscription
 
 import 'package:flutter/material.dart';
+import 'package:paw_sync/features/pet_profile/models/pet_model.dart'; // Added Pet model import
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:paw_sync/core/auth/providers/auth_providers.dart'; // Import auth providers


### PR DESCRIPTION
- Added missing import for Pet model in app_router.dart to resolve "'Pet' isn't a type" error.
- Investigated errors related to missing form widget definitions in PetDetailScreen. Provided user with corrected full file content for PetDetailScreen to resolve these due to tool limitations in accessing the file directly.
- Investigated error regarding 'uploadPetProfileImage' in SavePetScreen; code appears correct, likely a cascading error from other issues.
- Provided guidance to user on the critical need to run `flutterfire configure` to generate `firebase_options.dart`, which is the root cause of Firebase initialization failures.